### PR TITLE
Update wrf.py for 4.5.2

### DIFF
--- a/easybuild/easyblocks/w/wrf.py
+++ b/easybuild/easyblocks/w/wrf.py
@@ -56,7 +56,7 @@ def det_wrf_subdir(wrf_version):
 
     if LooseVersion(wrf_version) < LooseVersion('4.0'):
         wrf_subdir = 'WRFV%s' % wrf_version.split('.')[0]
-    elif LooseVersion(wrf_version) >= LooseVersion('4.5.1'):
+    elif LooseVersion(wrf_version) == LooseVersion('4.5.1'): # WRF 4.5.2 actually use "WRF-4.5.2" directory naming scheme.
         wrf_subdir = 'WRFV%s' % wrf_version
     else:
         wrf_subdir = 'WRF-%s' % wrf_version


### PR DESCRIPTION
I thought I made a proposed change, but couldn't find it. Please discard this if duplicated. This change is to fix the sanity-check step of WRF 4.5.2. Somehow WRF 4.5.2 decides to go back to "WRF-4.5.2" directory naming scheme (instead of "WRFV4.5.2"). I'm about to start another pull request to add my WRF 4.5.2 easybuild config file with intel 2023a toolchain and an associated patch file, so I need this change to go through before proceeding. Thanks!